### PR TITLE
feat(script): add ims system image module script

### DIFF
--- a/examples/ims-ecs-system-image/README.md
+++ b/examples/ims-ecs-system-image/README.md
@@ -1,0 +1,71 @@
+# IMS ECS system image example
+
+Configuration in this directory creates an IMS ECS system image.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan -var-file=variables.json
+$ terraform apply -var-file=variables.json
+```
+
+Run `terraform destroy -var-file=variables.json` when you don't need these resources.
+
+## Requirements
+
+| Name                 | Version   |
+|----------------------|-----------|
+| Terraform            | >= 1.3.0  |
+| Huaweicloud Provider | >= 1.73.0 |
+
+## Modules
+
+<!-- markdownlint-disable MD013 -->
+| Name             | Source                                                                                                  | Version |
+|------------------|---------------------------------------------------------------------------------------------------------|---------|
+| vpc_network      | [terraform-huaweicloud-vpc](https://github.com/terraform-huaweicloud-modules/terraform-huaweicloud-vpc) | v1.2.0  |
+| ecs_instance     | [terraform-huaweicloud-ecs](https://github.com/terraform-huaweicloud-modules/terraform-huaweicloud-ecs) | N/A     |
+| ims_system_image | [../../modules/ims-system-image](../../modules/ims-system-image/README.md)                              | N/A     |
+<!-- markdownlint-enable MD013 -->
+
+## Resources
+
+| Name                                     | Type        |
+|------------------------------------------|-------------|
+| random_password.this                     | resource    |
+| data.huaweicloud_availability_zones.this | data source |
+
+## Inputs
+
+<!-- markdownlint-disable MD013 -->
+| Name                                   | Description                                                                                                              | Value                                                                                                  |
+|----------------------------------------|--------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
+| vpc_enterprise_project_id              | The enterprise project ID of the vpc. For enterprise users, if omitted, default enterprise project will be used          | `0`                                                                                                    |
+| vpc_name                               | The name of the VPC to which the ECS instance belongs                                                                    | `"vpc-test-module"`                                                                                    |
+| vpc_cidr                               | The CIDR block of the VPC to which the ECS instance belongs                                                              | `"192.168.0.0/16"`                                                                                     |
+| subnets_configuration                  | The configuration for the subnets to which the ECS instance belongs                                                      | <pre>[<br>  {<br>    name = "vpc-subnet-test-module",<br>    cidr = "192.168.0.0/24"<br>  }<br>]</pre> |
+| security_group_name                    | The name of the security group to which the ECS instance belongs                                                         | `"security_group-test-module"`                                                                         |
+| ecs_instance_enterprise_project_id     | The enterprise project ID of the ECS instance. For enterprise users, if omitted, default enterprise project will be used | `0`                                                                                                    |
+| instance_flavor_cpu_core_count         | The CPU core number of the ECS instance flavor to be queried                                                             | `4`                                                                                                    |
+| instance_flavor_memory_size            | The memory size of the ECS instance flavor to be queried                                                                 | `8`                                                                                                    |
+| instance_image_os_type                 | The OS type of the IMS image to be queried that the ECS instance used                                                    | `"CentOS"`                                                                                             |
+| instance_image_architecture            | The architecture of the IMS image to be queried that the ECS instance used                                               | `"x86"`                                                                                                |
+| instance_name                          | The name of the ECS instance                                                                                             | `"ecs-test-module"`                                                                                    |
+| instance_disks_configuration           | The disks configuration to attach to the ECS instance                                                                    | <pre>[<br>  {<br>    is_system_disk = true,<br>    type = "SSD",<br>    size = 200<br>  }<br>]</pre>   |
+| ecs_system_image_name                  | The name of the image                                                                                                    | `"ecs-image-test-module"`                                                                              |
+| ecs_system_image_description           | The description of the image                                                                                             | `"description test"`                                                                                   |
+| ecs_system_image_max_ram               | The maximum memory of the image, in MB unit                                                                              | `1024`                                                                                                 |
+| ecs_system_image_min_ram               | The minimum memory of the image, in MB unit                                                                              | `1024`                                                                                                 |
+| ecs_system_image_tags                  | The key/value pairs to associate with the image                                                                          | <pre>{<br>  foo = "bar"<br>  key = "value"<br>}</pre>                                                  |
+| ecs_system_image_enterprise_project_id | The enterprise project ID of the image. For enterprise users, if omitted, default enterprise project will be used        | `0`                                                                                                    |
+<!-- markdownlint-enable MD013 -->
+
+## Outputs
+
+| Name                    | Description             |
+|-------------------------|-------------------------|
+| ecs_system_image_id     | The ID of the image     |
+| ecs_system_image_status | The status of the image |

--- a/examples/ims-ecs-system-image/main.tf
+++ b/examples/ims-ecs-system-image/main.tf
@@ -1,0 +1,58 @@
+resource "random_password" "this" {
+  length           = 16
+  special          = true
+  min_numeric      = 1
+  min_special      = 1
+  min_lower        = 1
+  min_upper        = 1
+  override_special = "!#"
+}
+
+data "huaweicloud_availability_zones" "this" {}
+
+module "vpc_network" {
+  source = "github.com/terraform-huaweicloud-modules/terraform-huaweicloud-vpc?ref=v1.2.0"
+
+  enterprise_project_id = var.vpc_enterprise_project_id
+  availability_zone     = try(data.huaweicloud_availability_zones.this.names[0], "")
+
+  vpc_name              = var.vpc_name
+  vpc_cidr              = var.vpc_cidr
+  subnets_configuration = var.subnets_configuration
+  security_group_name   = var.security_group_name
+}
+
+module "ecs_instance" {
+  source = "github.com/terraform-huaweicloud-modules/terraform-huaweicloud-ecs"
+
+  enterprise_project_id = var.ecs_instance_enterprise_project_id
+  availability_zone     = try(data.huaweicloud_availability_zones.this.names[0], "")
+
+  instance_flavor_cpu_core_count      = var.instance_flavor_cpu_core_count
+  instance_flavor_memory_size         = var.instance_flavor_memory_size
+  instance_image_os_type              = var.instance_image_os_type
+  instance_image_architecture         = var.instance_image_architecture
+  instance_name                       = var.instance_name
+  instance_admin_pass                 = random_password.this.result
+  instance_security_group_ids         = [module.vpc_network.security_group_id]
+  use_inside_data_disks_configuration = true
+  instance_disks_configuration        = var.instance_disks_configuration
+
+  instance_networks_configuration = try(module.vpc_network.subnet_ids[0], "") != "" ? [
+    {
+      uuid = try(module.vpc_network.subnet_ids[0], "")
+    }
+  ] : []
+}
+
+module "ims_ecs_system_image" {
+  source = "../../modules/ims-system-image"
+
+  ecs_system_image_name                  = var.ecs_system_image_name
+  ecs_system_image_instance_id           = module.ecs_instance.instance_id
+  ecs_system_image_description           = var.ecs_system_image_description
+  ecs_system_image_max_ram               = var.ecs_system_image_max_ram
+  ecs_system_image_min_ram               = var.ecs_system_image_min_ram
+  ecs_system_image_tags                  = var.ecs_system_image_tags
+  ecs_system_image_enterprise_project_id = var.ecs_system_image_enterprise_project_id
+}

--- a/examples/ims-ecs-system-image/outputs.tf
+++ b/examples/ims-ecs-system-image/outputs.tf
@@ -1,0 +1,9 @@
+output "ecs_system_image_id" {
+  description = "The ID of the image"
+  value       = module.ims_ecs_system_image.ecs_system_image_id
+}
+
+output "ecs_system_image_status" {
+  description = "The status of the image"
+  value       = module.ims_ecs_system_image.ecs_system_image_status
+}

--- a/examples/ims-ecs-system-image/variables.json
+++ b/examples/ims-ecs-system-image/variables.json
@@ -1,0 +1,36 @@
+{
+  "vpc_enterprise_project_id": "0",
+  "vpc_name": "vpc-test-module",
+  "vpc_cidr": "192.168.0.0/16",
+  "subnets_configuration": [
+    {
+      "name": "vpc-subnet-test-module",
+      "cidr": "192.168.0.0/24"
+    }
+  ],
+  "security_group_name": "security_group-test-module",
+
+  "ecs_instance_enterprise_project_id": "0",
+  "instance_flavor_cpu_core_count": 4,
+  "instance_flavor_memory_size": 8,
+  "instance_image_os_type": "CentOS",
+  "instance_image_architecture": "x86",
+  "instance_name": "ecs-test-module",
+  "instance_disks_configuration": [
+    {
+      "is_system_disk": true,
+      "type": "SSD",
+      "size": 200
+    }
+  ],
+
+  "ecs_system_image_name": "ecs-image-test-module",
+  "ecs_system_image_description": "description test",
+  "ecs_system_image_max_ram": 1024,
+  "ecs_system_image_min_ram": 1024,
+  "ecs_system_image_tags": {
+    "foo": "bar",
+    "key": "value"
+  },
+  "ecs_system_image_enterprise_project_id": "0"
+}

--- a/examples/ims-ecs-system-image/variables.tf
+++ b/examples/ims-ecs-system-image/variables.tf
@@ -1,0 +1,117 @@
+######################################################################
+# Configurations of the VPC resource and related resources
+######################################################################
+
+variable "vpc_enterprise_project_id" {
+  type        = string
+  description = "The enterprise project ID of the vpc. For enterprise users, if omitted, default enterprise project will be used"
+}
+
+variable "vpc_name" {
+  type        = string
+  description = "The name of the VPC to which the ECS instance belongs"
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "The CIDR block of the VPC to which the ECS instance belongs"
+}
+
+variable "subnets_configuration" {
+  type = list(object({
+    name = string
+    cidr = string
+  }))
+
+  description = "The configuration for the subnets to which the ECS instance belongs"
+}
+
+variable "security_group_name" {
+  type        = string
+  description = "The name of the security group to which the ECS instance belongs"
+}
+
+######################################################################
+# Configurations of ECS resource and related resources
+######################################################################
+
+variable "ecs_instance_enterprise_project_id" {
+  type        = string
+  description = "The enterprise project ID of the ECS instance. For enterprise users, if omitted, default enterprise project will be used"
+}
+
+variable "instance_flavor_cpu_core_count" {
+  type        = number
+  description = "The CPU core number of the ECS instance flavor to be queried"
+}
+
+variable "instance_flavor_memory_size" {
+  type        = number
+  description = "The memory size of the ECS instance flavor to be queried"
+}
+
+variable "instance_image_os_type" {
+  type        = string
+  description = "The OS type of the IMS image to be queried that the ECS instance used"
+}
+
+variable "instance_image_architecture" {
+  type        = string
+  description = "The architecture of the IMS image to be queried that the ECS instance used"
+}
+
+variable "instance_name" {
+  type        = string
+  description = "The name of the ECS instance"
+}
+
+variable "instance_disks_configuration" {
+  type = list(object({
+    is_system_disk = bool
+    name           = optional(string, "")
+    type           = string
+    size           = number
+  }))
+
+  description = "The disks configuration to attach to the ECS instance"
+}
+
+######################################################################
+# Configurations of the IMS ECS system image resource
+######################################################################
+
+variable "is_ecs_system_image_create" {
+  type        = bool
+  description = "Controls whether the IMS ECS system image should be created"
+  default     = true
+}
+
+variable "ecs_system_image_name" {
+  type        = string
+  description = "The name of the image"
+}
+
+variable "ecs_system_image_description" {
+  type        = string
+  description = "The description of the image"
+}
+
+variable "ecs_system_image_max_ram" {
+  type        = number
+  description = "The maximum memory of the image, in MB unit"
+}
+
+variable "ecs_system_image_min_ram" {
+  type        = number
+  description = "The minimum memory of the image, in MB unit"
+}
+
+variable "ecs_system_image_tags" {
+  type        = map(string)
+  description = "The key/value pairs to associate with the image"
+}
+
+variable "ecs_system_image_enterprise_project_id" {
+  type        = string
+  description = "The enterprise project ID of the image. For enterprise users, if omitted, default enterprise project will be used"
+}

--- a/examples/ims-ecs-system-image/versions.tf
+++ b/examples/ims-ecs-system-image/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.73.0"
+    }
+  }
+}

--- a/modules/ims-system-image/README.md
+++ b/modules/ims-system-image/README.md
@@ -1,0 +1,97 @@
+# IMS system image management
+
+Manages the IMS system image resource.
+
+## Notes
+
+### How to import resources in the module structure
+
+If you want to manage an existing IMS system image using Terraform (otherwise why are you reading this?) you need to
+make sure that the corresponding module script has been defined in your `.tf` file, like this:
+
+```hcl
+# Manages an IMS system image.
+module "ims_system_image" {
+  source = "github.com/terraform-huaweicloud-modules/terraform-huaweicloud-ims/modules/ims-system-image"
+
+  ...
+}
+```
+
+Then, execute the following command to import the corresponding resource into the management of the `.tfstate` file.
+
+```bash
+$ terraform import module.ims_system_image.huaweicloud_ims_ecs_system_image.this[0] "ecs_system_image_id"
+
+module.ims_system_image.huaweicloud_ims_ecs_system_image.this[0]: Importing from ID "ecs_system_image_id"...
+module.ims_system_image.huaweicloud_ims_ecs_system_image.this[0]: Import prepared!
+  Prepared huaweicloud_ims_ecs_system_image for import
+module.ims_system_image.huaweicloud_ims_ecs_system_image.this[0]: Refreshing state... [id=ecs_system_image_id]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
+### What should we do before deploy this module example
+
+Before manage IMS resources, the access key (AK, the corresponding environment name is `HW_ACCESS_KEY`) and the secret
+key (SK, the corresponding environment name is `HW_SECRET_KEY`) should be configured.
+
+For the linux VM, you can configure the corresponding environment variables with the following commands:
+
+```bash
+$ export HW_ACCESS_KEY=XXXXXXXXXXXXXXXXXXXX
+$ export HW_SECRET_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+```
+
+Refer to this [document](https://support.huaweicloud.com/intl/en-us/devg-apisign/api-sign-provide-aksk.html) for AK/SK
+information obtain.
+
+## Contributing
+
+Report issues/questions/feature requests in
+the [issues](https://github.com/terraform-huaweicloud-modules/terraform-huaweicloud-ims/issues/new)
+section.
+
+Full contributing [guidelines are covered here](../../.github/how_to_contribute.md).
+
+## Requirements
+
+| Name                 | Version   |
+|----------------------|-----------|
+| Terraform            | >= 1.3.0  |
+| Huaweicloud Provider | >= 1.73.0 |
+
+## Modules
+
+No module.
+
+## Resources
+
+| Name                                  | Type     |
+|---------------------------------------|----------|
+| huaweicloud_ims_ecs_system_image.this | resource |
+
+## Inputs
+
+<!-- markdownlint-disable MD013 -->
+| Name                                   | Description                                                                                                       | Type                     | Default |                     Required                                |
+|----------------------------------------|-------------------------------------------------------------------------------------------------------------------|--------------------------|:-------:|:-----------------------------------------------------------:|
+| is_ecs_system_image_create             | Controls whether the IMS ECS system image should be created                                                       | `bool`                   | `true`  |                         N                                   |
+| ecs_system_image_name                  | The name of the image                                                                                             | `string`                 | `null`  | Y (Unless is_ecs_system_image_create is specified as false) |
+| ecs_system_image_instance_id           | The source ECS instance ID used to create the image                                                               | `string`                 | `null`  | Y (Unless is_ecs_system_image_create is specified as false) |
+| ecs_system_image_description           | The description of the image                                                                                      | `string`                 | `null`  |                         N                                   |
+| ecs_system_image_max_ram               | The maximum memory of the image, in MB unit                                                                       | `number`                 | `null`  |                         N                                   |
+| ecs_system_image_min_ram               | The minimum memory of the image, in MB unit                                                                       | `number`                 | `null`  |                         N                                   |
+| ecs_system_image_tags                  | The key/value pairs to associate with the image                                                                   | `<pre>map(string)</pre>` | `null`  |                         N                                   |
+| ecs_system_image_enterprise_project_id | The enterprise project ID of the image. For enterprise users, if omitted, default enterprise project will be used | `string`                 | `null`  |                         N                                   |
+<!-- markdownlint-enable MD013 -->
+
+## Outputs
+
+| Name                    | Description             |
+|-------------------------|-------------------------|
+| ecs_system_image_id     | The ID of the image     |
+| ecs_system_image_status | The status of the image |

--- a/modules/ims-system-image/main.tf
+++ b/modules/ims-system-image/main.tf
@@ -1,0 +1,11 @@
+resource "huaweicloud_ims_ecs_system_image" "this" {
+  count = var.is_ecs_system_image_create ? 1 : 0
+
+  name                  = var.ecs_system_image_name
+  instance_id           = var.ecs_system_image_instance_id
+  description           = var.ecs_system_image_description
+  max_ram               = var.ecs_system_image_max_ram
+  min_ram               = var.ecs_system_image_min_ram
+  tags                  = var.ecs_system_image_tags
+  enterprise_project_id = var.ecs_system_image_enterprise_project_id
+}

--- a/modules/ims-system-image/outputs.tf
+++ b/modules/ims-system-image/outputs.tf
@@ -1,0 +1,9 @@
+output "ecs_system_image_id" {
+  description = "The ID of the image"
+  value       = try(huaweicloud_ims_ecs_system_image.this[0].id, "")
+}
+
+output "ecs_system_image_status" {
+  description = "The status of the image"
+  value       = try(huaweicloud_ims_ecs_system_image.this[0].status, "")
+}

--- a/modules/ims-system-image/variables.tf
+++ b/modules/ims-system-image/variables.tf
@@ -1,0 +1,52 @@
+######################################################################
+# Configurations of the IMS ECS system image resource
+######################################################################
+
+variable "is_ecs_system_image_create" {
+  type        = bool
+  description = "Controls whether the IMS ECS system image should be created"
+  default     = true
+  nullable    = false
+}
+
+variable "ecs_system_image_name" {
+  type        = string
+  description = "The name of the image"
+  default     = null
+}
+
+variable "ecs_system_image_instance_id" {
+  type        = string
+  description = "The source ECS instance ID used to create the image"
+  default     = null
+}
+
+variable "ecs_system_image_description" {
+  type        = string
+  description = "The description of the image"
+  default     = null
+}
+
+variable "ecs_system_image_max_ram" {
+  type        = number
+  description = "The maximum memory of the image, in MB unit"
+  default     = null
+}
+
+variable "ecs_system_image_min_ram" {
+  type        = number
+  description = "The minimum memory of the image, in MB unit"
+  default     = null
+}
+
+variable "ecs_system_image_tags" {
+  type        = map(string)
+  description = "The key/value pairs to associate with the image"
+  default     = null
+}
+
+variable "ecs_system_image_enterprise_project_id" {
+  type        = string
+  description = "The enterprise project ID of the image. For enterprise users, if omitted, default enterprise project will be used"
+  default     = null
+}

--- a/modules/ims-system-image/versions.tf
+++ b/modules/ims-system-image/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.73.0"
+    }
+  }
+}


### PR DESCRIPTION
# Add ims system image module script

## Test running ims_system_image module
```
$ terraform apply -var-file=variables.json

data.huaweicloud_availability_zones.this: Reading...
data.huaweicloud_availability_zones.this: Read complete after 0s [id=74326821]
module.ecs_instance.data.huaweicloud_compute_flavors.this[0]: Reading...
module.ecs_instance.data.huaweicloud_compute_flavors.this[0]: Read complete after 1s [id=2232540632]
module.ecs_instance.data.huaweicloud_images_images.this[0]: Reading...
module.ecs_instance.data.huaweicloud_images_images.this[0]: Read complete after 1s [id=686217973]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # random_password.this will be created
  + resource "random_password" "this" {
      + bcrypt_hash      = (sensitive value)
      + id               = (known after apply)
      + length           = 16
      + lower            = true
      + min_lower        = 1
      + min_numeric      = 1
      + min_special      = 1
      + min_upper        = 1
      + number           = true
      + numeric          = true
      + override_special = "!#"
      + result           = (sensitive value)
      + special          = true
      + upper            = true
    }

  # module.ecs_instance.huaweicloud_compute_instance.this[0] will be created
  + resource "huaweicloud_compute_instance" "this" {
      + access_ip_v4              = (known after apply)
      + access_ip_v6              = (known after apply)
      + admin_pass                = (sensitive value)
      + agency_name               = (known after apply)
      + agent_list                = (known after apply)
      + availability_zone         = "cn-north-4a"
      + charging_mode             = (known after apply)
      + created_at                = (known after apply)
      + delete_eip_on_termination = true
      + description               = (known after apply)
      + enterprise_project_id     = "0"
      + expired_time              = (known after apply)
      + flavor_id                 = "s6.xlarge.2"
      + flavor_name               = (known after apply)
      + hostname                  = (known after apply)
      + id                        = (known after apply)
      + image_id                  = "8691606a-9355-42b5-a549-1bbf32738d71"
      + image_name                = (known after apply)
      + name                      = "ecs-test-module"
      + power_action              = (known after apply)
      + public_ip                 = (known after apply)
      + region                    = (known after apply)
      + security_group_ids        = (known after apply)
      + security_groups           = (known after apply)
      + spot_duration             = 0
      + spot_duration_count       = 0
      + status                    = (known after apply)
      + stop_before_destroy       = false
      + system_disk_id            = (known after apply)
      + system_disk_iops          = 0
      + system_disk_kms_key_id    = (known after apply)
      + system_disk_size          = 200
      + system_disk_throughput    = 0
      + system_disk_type          = "SSD"
      + updated_at                = (known after apply)
      + volume_attached           = (known after apply)
    }

  # module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0] will be created
  + resource "huaweicloud_ims_ecs_system_image" "this" {
      + active_at             = (known after apply)
      + created_at            = (known after apply)
      + data_origin           = (known after apply)
      + description           = "description test"
      + disk_format           = (known after apply)
      + enterprise_project_id = "0"
      + id                    = (known after apply)
      + image_size            = (known after apply)
      + instance_id           = (known after apply)
      + max_ram               = 1024
      + min_disk              = (known after apply)
      + min_ram               = 1024
      + name                  = "ecs-image-test-module"
      + os_version            = (known after apply)
      + region                = (known after apply)
      + status                = (known after apply)
      + tags                  = {
          + "foo" = "bar"
          + "key" = "value"
        }
      + updated_at            = (known after apply)
      + visibility            = (known after apply)
    }

  # module.vpc_network.data.huaweicloud_networking_secgroup_rules.this[0] will be read during apply
  # (config refers to values not yet known)
 <= data "huaweicloud_networking_secgroup_rules" "this" {
      + id                = (known after apply)
      + region            = (known after apply)
      + rules             = (known after apply)
      + security_group_id = (known after apply)
    }

  # module.vpc_network.huaweicloud_networking_secgroup.this[0] will be created
  + resource "huaweicloud_networking_secgroup" "this" {
      + created_at            = (known after apply)
      + delete_default_rules  = true
      + enterprise_project_id = "0"
      + id                    = (known after apply)
      + name                  = "security_group-test-module"
      + region                = (known after apply)
      + rules                 = (known after apply)
      + updated_at            = (known after apply)
    }

  # module.vpc_network.huaweicloud_networking_secgroup_rule.in_v4_self_group[0] will be created
  + resource "huaweicloud_networking_secgroup_rule" "in_v4_self_group" {
      + action                  = (known after apply)
      + direction               = "ingress"
      + ethertype               = "IPv4"
      + id                      = (known after apply)
      + port_range_max          = (known after apply)
      + port_range_min          = (known after apply)
      + ports                   = (known after apply)
      + priority                = (known after apply)
      + protocol                = (known after apply)
      + region                  = (known after apply)
      + remote_address_group_id = (known after apply)
      + remote_group_id         = (known after apply)
      + remote_ip_prefix        = (known after apply)
      + security_group_id       = (known after apply)
    }

  # module.vpc_network.huaweicloud_vpc.this[0] will be created
  + resource "huaweicloud_vpc" "this" {
      + cidr                  = "192.168.0.0/16"
      + enhanced_local_route  = (known after apply)
      + enterprise_project_id = "0"
      + id                    = (known after apply)
      + name                  = "vpc-test-module"
      + region                = (known after apply)
      + routes                = (known after apply)
      + secondary_cidrs       = (known after apply)
      + status                = (known after apply)
    }

  # module.vpc_network.huaweicloud_vpc_subnet.this[0] will be created
  + resource "huaweicloud_vpc_subnet" "this" {
      + availability_zone = (known after apply)
      + cidr              = "192.168.0.0/24"
      + dhcp_enable       = true
      + dhcp_lease_time   = (known after apply)
      + dns_list          = (known after apply)
      + gateway_ip        = "192.168.0.1"
      + id                = (known after apply)
      + ipv4_subnet_id    = (known after apply)
      + ipv6_cidr         = (known after apply)
      + ipv6_gateway      = (known after apply)
      + ipv6_subnet_id    = (known after apply)
      + name              = "vpc-subnet-test-module"
      + primary_dns       = (known after apply)
      + region            = (known after apply)
      + secondary_dns     = (known after apply)
      + subnet_id         = (known after apply)
      + vpc_id            = (known after apply)
    }

Plan: 7 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + ecs_system_image_id     = (known after apply)
  + ecs_system_image_status = (known after apply)

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

random_password.this: Creating...
random_password.this: Creation complete after 0s [id=none]
module.vpc_network.huaweicloud_networking_secgroup.this[0]: Creating...
module.vpc_network.huaweicloud_vpc.this[0]: Creating...
module.vpc_network.huaweicloud_networking_secgroup.this[0]: Creation complete after 1s [id=f738ad42-75b4-4f70-a21c-1a97735f26c4]
module.vpc_network.huaweicloud_networking_secgroup_rule.in_v4_self_group[0]: Creating...
module.vpc_network.huaweicloud_networking_secgroup_rule.in_v4_self_group[0]: Creation complete after 1s [id=67173307-f0b9-4781-8ee3-d78a442bca3a]
module.vpc_network.data.huaweicloud_networking_secgroup_rules.this[0]: Reading...
module.vpc_network.data.huaweicloud_networking_secgroup_rules.this[0]: Read complete after 0s [id=cffa1ed4-9b8f-a037-9d6c-48e29b56df17]
module.vpc_network.huaweicloud_vpc.this[0]: Creation complete after 7s [id=643b3bab-a716-45e7-80f0-5aef33e91470]
module.vpc_network.huaweicloud_vpc_subnet.this[0]: Creating...
module.vpc_network.huaweicloud_vpc_subnet.this[0]: Creation complete after 9s [id=15e8e6e2-cdec-4a1f-b716-69e90f3b5e1e]
module.ecs_instance.huaweicloud_compute_instance.this[0]: Creating...
module.ecs_instance.huaweicloud_compute_instance.this[0]: Still creating... [10s elapsed]
module.ecs_instance.huaweicloud_compute_instance.this[0]: Still creating... [20s elapsed]
module.ecs_instance.huaweicloud_compute_instance.this[0]: Still creating... [30s elapsed]
module.ecs_instance.huaweicloud_compute_instance.this[0]: Still creating... [40s elapsed]
module.ecs_instance.huaweicloud_compute_instance.this[0]: Creation complete after 46s [id=b9d39062-b44d-4a7b-afd2-ac6f128da836]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Creating...
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Still creating... [10s elapsed]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Still creating... [20s elapsed]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Still creating... [30s elapsed]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Still creating... [40s elapsed]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Still creating... [50s elapsed]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Still creating... [1m0s elapsed]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Still creating... [1m10s elapsed]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Still creating... [1m20s elapsed]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Still creating... [1m30s elapsed]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Still creating... [1m40s elapsed]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Still creating... [1m50s elapsed]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Still creating... [2m0s elapsed]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Still creating... [2m10s elapsed]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Still creating... [2m20s elapsed]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Still creating... [2m30s elapsed]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Still creating... [2m40s elapsed]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Still creating... [2m50s elapsed]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Still creating... [3m0s elapsed]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Creation complete after 3m5s [id=199b8571-815f-4529-97b6-f3b746434a73]

Apply complete! Resources: 7 added, 0 changed, 0 destroyed.

Outputs:

ecs_system_image_id = "199b8571-815f-4529-97b6-f3b746434a73"
ecs_system_image_status = "active"

```


## Test destroying ims_system_image module
```
$ terraform destroy -var-file=variables.json

random_password.this: Refreshing state... [id=none]
data.huaweicloud_availability_zones.this: Reading...
module.vpc_network.huaweicloud_networking_secgroup.this[0]: Refreshing state... [id=f738ad42-75b4-4f70-a21c-1a97735f26c4]
module.vpc_network.huaweicloud_vpc.this[0]: Refreshing state... [id=643b3bab-a716-45e7-80f0-5aef33e91470]
data.huaweicloud_availability_zones.this: Read complete after 0s [id=74326821]
module.ecs_instance.data.huaweicloud_compute_flavors.this[0]: Reading...
module.vpc_network.huaweicloud_networking_secgroup_rule.in_v4_self_group[0]: Refreshing state... [id=67173307-f0b9-4781-8ee3-d78a442bca3a]
module.vpc_network.huaweicloud_vpc_subnet.this[0]: Refreshing state... [id=15e8e6e2-cdec-4a1f-b716-69e90f3b5e1e]
module.vpc_network.data.huaweicloud_networking_secgroup_rules.this[0]: Reading...
module.vpc_network.data.huaweicloud_networking_secgroup_rules.this[0]: Read complete after 0s [id=58255f91-7007-f0b2-6f76-a0f0e03ce95a]
module.ecs_instance.data.huaweicloud_compute_flavors.this[0]: Read complete after 2s [id=2232540632]
module.ecs_instance.data.huaweicloud_images_images.this[0]: Reading...
module.ecs_instance.data.huaweicloud_images_images.this[0]: Read complete after 2s [id=686217973]
module.ecs_instance.huaweicloud_compute_instance.this[0]: Refreshing state... [id=b9d39062-b44d-4a7b-afd2-ac6f128da836]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Refreshing state... [id=199b8571-815f-4529-97b6-f3b746434a73]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # random_password.this will be destroyed
  - resource "random_password" "this" {
      - bcrypt_hash      = (sensitive value) -> null
      - id               = "none" -> null
      - length           = 16 -> null
      - lower            = true -> null
      - min_lower        = 1 -> null
      - min_numeric      = 1 -> null
      - min_special      = 1 -> null
      - min_upper        = 1 -> null
      - number           = true -> null
      - numeric          = true -> null
      - override_special = "!#" -> null
      - result           = (sensitive value) -> null
      - special          = true -> null
      - upper            = true -> null
    }

  # module.ecs_instance.huaweicloud_compute_instance.this[0] will be destroyed
  - resource "huaweicloud_compute_instance" "this" {
      - access_ip_v4              = "192.168.0.30" -> null
      - admin_pass                = (sensitive value) -> null
      - availability_zone         = "cn-north-4a" -> null
      - charging_mode             = "postPaid" -> null
      - created_at                = "2025-03-28T03:02:29Z" -> null
      - delete_eip_on_termination = true -> null
      - enterprise_project_id     = "0" -> null
      - flavor_id                 = "s6.xlarge.2" -> null
      - flavor_name               = "s6.xlarge.2" -> null
      - hostname                  = "ecs-test-module" -> null
      - id                        = "b9d39062-b44d-4a7b-afd2-ac6f128da836" -> null
      - image_id                  = "8691606a-9355-42b5-a549-1bbf32738d71" -> null
      - image_name                = "CentOS 6.10 64bit" -> null
      - name                      = "ecs-test-module" -> null
      - region                    = "cn-north-4" -> null
      - security_group_ids        = [
          - "f738ad42-75b4-4f70-a21c-1a97735f26c4",
        ] -> null
      - security_groups           = [
          - "security_group-test-module",
        ] -> null
      - spot_duration             = 0 -> null
      - spot_duration_count       = 0 -> null
      - status                    = "ACTIVE" -> null
      - stop_before_destroy       = false -> null
      - system_disk_id            = "0da914ff-005e-4da0-a337-2085ef0013f4" -> null
      - system_disk_iops          = 0 -> null
      - system_disk_size          = 200 -> null
      - system_disk_throughput    = 0 -> null
      - system_disk_type          = "SSD" -> null
      - tags                      = {} -> null
      - updated_at                = "2025-03-28T03:05:49Z" -> null
      - volume_attached           = [
          - {
              - boot_index  = 0
              - kms_key_id  = ""
              - pci_address = "0000:02:01.0"
              - size        = 200
              - type        = "SSD"
              - volume_id   = "0da914ff-005e-4da0-a337-2085ef0013f4"
            },
        ] -> null

      - network {
          - access_network    = false -> null
          - fixed_ip_v4       = "192.168.0.30" -> null
          - ipv6_enable       = false -> null
          - mac               = "fa:16:3e:18:70:8e" -> null
          - port              = "d2479dd0-f445-4145-9020-6a3a566ef948" -> null
          - source_dest_check = true -> null
          - uuid              = "15e8e6e2-cdec-4a1f-b716-69e90f3b5e1e" -> null
        }
    }

  # module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0] will be destroyed
  - resource "huaweicloud_ims_ecs_system_image" "this" {
      - active_at             = "2025-03-28T03:05:48Z" -> null
      - created_at            = "2025-03-28T03:03:14Z" -> null
      - data_origin           = "instance,b9d39062-b44d-4a7b-afd2-ac6f128da836" -> null
      - description           = "description test" -> null
      - disk_format           = "zvhd2" -> null
      - enterprise_project_id = "0" -> null
      - id                    = "199b8571-815f-4529-97b6-f3b746434a73" -> null
      - image_size            = "1030971392" -> null
      - instance_id           = "b9d39062-b44d-4a7b-afd2-ac6f128da836" -> null
      - max_ram               = 1024 -> null
      - min_disk              = 200 -> null
      - min_ram               = 1024 -> null
      - name                  = "ecs-image-test-module" -> null
      - os_version            = "CentOS 6.10 64bit" -> null
      - region                = "cn-north-4" -> null
      - status                = "active" -> null
      - tags                  = {
          - "foo" = "bar"
          - "key" = "value"
        } -> null
      - updated_at            = "2025-03-28T03:06:13Z" -> null
      - visibility            = "private" -> null
    }

  # module.vpc_network.huaweicloud_networking_secgroup.this[0] will be destroyed
  - resource "huaweicloud_networking_secgroup" "this" {
      - created_at            = "2025-03-28T03:02:08Z" -> null
      - delete_default_rules  = true -> null
      - enterprise_project_id = "0" -> null
      - id                    = "f738ad42-75b4-4f70-a21c-1a97735f26c4" -> null
      - name                  = "security_group-test-module" -> null
      - region                = "cn-north-4" -> null
      - rules                 = [
          - {
              - action                  = "allow"
              - description             = ""
              - direction               = "ingress"
              - ethertype               = "IPv4"
              - id                      = "67173307-f0b9-4781-8ee3-d78a442bca3a"
              - port_range_max          = 0
              - port_range_min          = 0
              - ports                   = ""
              - priority                = 1
              - protocol                = ""
              - remote_address_group_id = ""
              - remote_group_id         = "f738ad42-75b4-4f70-a21c-1a97735f26c4"
              - remote_ip_prefix        = ""
            },
        ] -> null
      - tags                  = {} -> null
      - updated_at            = "2025-03-28T03:02:08Z" -> null
    }

  # module.vpc_network.huaweicloud_networking_secgroup_rule.in_v4_self_group[0] will be destroyed
  - resource "huaweicloud_networking_secgroup_rule" "in_v4_self_group" {
      - action            = "allow" -> null
      - direction         = "ingress" -> null
      - ethertype         = "IPv4" -> null
      - id                = "67173307-f0b9-4781-8ee3-d78a442bca3a" -> null
      - port_range_max    = 0 -> null
      - port_range_min    = 0 -> null
      - priority          = 1 -> null
      - region            = "cn-north-4" -> null
      - remote_group_id   = "f738ad42-75b4-4f70-a21c-1a97735f26c4" -> null
      - security_group_id = "f738ad42-75b4-4f70-a21c-1a97735f26c4" -> null
    }

  # module.vpc_network.huaweicloud_vpc.this[0] will be destroyed
  - resource "huaweicloud_vpc" "this" {
      - cidr                  = "192.168.0.0/16" -> null
      - enhanced_local_route  = "false" -> null
      - enterprise_project_id = "0" -> null
      - id                    = "643b3bab-a716-45e7-80f0-5aef33e91470" -> null
      - name                  = "vpc-test-module" -> null
      - region                = "cn-north-4" -> null
      - routes                = [] -> null
      - secondary_cidrs       = [] -> null
      - status                = "OK" -> null
      - tags                  = {} -> null
    }

  # module.vpc_network.huaweicloud_vpc_subnet.this[0] will be destroyed
  - resource "huaweicloud_vpc_subnet" "this" {
      - cidr            = "192.168.0.0/24" -> null
      - dhcp_enable     = true -> null
      - dhcp_lease_time = "87600h" -> null
      - dns_list        = [
          - "100.125.1.250",
          - "100.125.129.250",
        ] -> null
      - gateway_ip      = "192.168.0.1" -> null
      - id              = "15e8e6e2-cdec-4a1f-b716-69e90f3b5e1e" -> null
      - ipv4_subnet_id  = "1f0a0e90-0278-4a8f-be5c-a78c9bd69bdb" -> null
      - ipv6_enable     = false -> null
      - name            = "vpc-subnet-test-module" -> null
      - primary_dns     = "100.125.1.250" -> null
      - region          = "cn-north-4" -> null
      - secondary_dns   = "100.125.129.250" -> null
      - subnet_id       = "1f0a0e90-0278-4a8f-be5c-a78c9bd69bdb" -> null
      - tags            = {} -> null
      - vpc_id          = "643b3bab-a716-45e7-80f0-5aef33e91470" -> null
    }

Plan: 0 to add, 0 to change, 7 to destroy.

Changes to Outputs:
  - ecs_system_image_id     = "199b8571-815f-4529-97b6-f3b746434a73" -> null
  - ecs_system_image_status = "active" -> null

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Destroying... [id=199b8571-815f-4529-97b6-f3b746434a73]
module.vpc_network.huaweicloud_networking_secgroup_rule.in_v4_self_group[0]: Destroying... [id=67173307-f0b9-4781-8ee3-d78a442bca3a]
module.ims_ecs_system_image.huaweicloud_ims_ecs_system_image.this[0]: Destruction complete after 9s
module.ecs_instance.huaweicloud_compute_instance.this[0]: Destroying... [id=b9d39062-b44d-4a7b-afd2-ac6f128da836]
module.vpc_network.huaweicloud_networking_secgroup_rule.in_v4_self_group[0]: Still destroying... [id=67173307-f0b9-4781-8ee3-d78a442bca3a, 11s elapsed]
module.vpc_network.huaweicloud_networking_secgroup_rule.in_v4_self_group[0]: Destruction complete after 12s
module.ecs_instance.huaweicloud_compute_instance.this[0]: Still destroying... [id=b9d39062-b44d-4a7b-afd2-ac6f128da836, 10s elapsed]
module.ecs_instance.huaweicloud_compute_instance.this[0]: Still destroying... [id=b9d39062-b44d-4a7b-afd2-ac6f128da836, 20s elapsed]
module.ecs_instance.huaweicloud_compute_instance.this[0]: Still destroying... [id=b9d39062-b44d-4a7b-afd2-ac6f128da836, 30s elapsed]
module.ecs_instance.huaweicloud_compute_instance.this[0]: Still destroying... [id=b9d39062-b44d-4a7b-afd2-ac6f128da836, 40s elapsed]
module.ecs_instance.huaweicloud_compute_instance.this[0]: Destruction complete after 46s
module.vpc_network.huaweicloud_vpc_subnet.this[0]: Destroying... [id=15e8e6e2-cdec-4a1f-b716-69e90f3b5e1e]
module.vpc_network.huaweicloud_networking_secgroup.this[0]: Destroying... [id=f738ad42-75b4-4f70-a21c-1a97735f26c4]
random_password.this: Destroying... [id=none]
random_password.this: Destruction complete after 0s
module.vpc_network.huaweicloud_networking_secgroup.this[0]: Destruction complete after 9s
module.vpc_network.huaweicloud_vpc_subnet.this[0]: Still destroying... [id=15e8e6e2-cdec-4a1f-b716-69e90f3b5e1e, 10s elapsed]
module.vpc_network.huaweicloud_vpc_subnet.this[0]: Destruction complete after 12s
module.vpc_network.huaweicloud_vpc.this[0]: Destroying... [id=643b3bab-a716-45e7-80f0-5aef33e91470]
module.vpc_network.huaweicloud_vpc.this[0]: Still destroying... [id=643b3bab-a716-45e7-80f0-5aef33e91470, 10s elapsed]
module.vpc_network.huaweicloud_vpc.this[0]: Destruction complete after 10s

Destroy complete! Resources: 7 destroyed.

```


## Test importing ims_system_image module
```
$ terraform import module.ims_system_image.huaweicloud_ims_ecs_system_image.this[0] 4165d873-a1cd-4aca-a559-d83661293af0

module.ims_system_image.huaweicloud_ims_ecs_system_image.this[0]: Importing from ID "4165d873-a1cd-4aca-a559-d83661293af0"...
module.ims_system_image.huaweicloud_ims_ecs_system_image.this[0]: Import prepared!
  Prepared huaweicloud_ims_ecs_system_image for import
module.ims_system_image.huaweicloud_ims_ecs_system_image.this[0]: Refreshing state... [id=4165d873-a1cd-4aca-a559-d83661293af0]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

```
